### PR TITLE
[FEAT] persistent wallet storage

### DIFF
--- a/prisma/migrations/20250607184626_add_wallet/migration.sql
+++ b/prisma/migrations/20250607184626_add_wallet/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "Wallet" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "mnemonic" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Wallet_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Wallet_userId_key" ON "Wallet"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Wallet" ADD CONSTRAINT "Wallet_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,15 @@ model User {
   image         String?
   accounts      Account[]
   sessions      Session[]
+  wallet        Wallet?
+}
+
+model Wallet {
+  id        String   @id @default(uuid())
+  userId    String   @unique
+  mnemonic  String
+  createdAt DateTime @default(now())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model VerificationToken {


### PR DESCRIPTION
## Summary
- add persistent wallet storage in Prisma
- derive accounts for user session
- allow mnemonic import
- keep wallet info in local storage for one week

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684488905a7883229e178b9ef28485cf