### PR TITLE
Fix wallet derivation with ethers v6

### DIFF
--- a/src/app/api/wallet/import/route.ts
+++ b/src/app/api/wallet/import/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { Wallet } from "ethers";
+import { Wallet, HDNodeWallet } from "ethers";
 import { authOptions } from "@/lib/auth";
 import prisma from "@/db";
 import { getServerSession } from "next-auth";
@@ -23,7 +23,7 @@ export async function POST(req: Request) {
   });
 
   const path = `m/44'/60'/0'/0/0`;
-  const derived = Wallet.fromPhrase(phrase, path);
+  const derived = HDNodeWallet.fromPhrase(phrase, undefined, path);
 
   return NextResponse.json({ address: derived.address, privateKey: derived.privateKey });
 }

--- a/src/app/api/wallet/route.ts
+++ b/src/app/api/wallet/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { Wallet } from "ethers";
+import { Wallet, HDNodeWallet } from "ethers";
 import { authOptions } from "@/lib/auth";
 import prisma from "@/db";
 import { getServerSession } from "next-auth";
@@ -26,7 +26,7 @@ export async function POST(req: Request) {
   }
 
   const path = `m/44'/60'/0'/0/${index}`;
-  const derived = Wallet.fromPhrase(wallet.mnemonic, path);
+  const derived = HDNodeWallet.fromPhrase(wallet.mnemonic, undefined, path);
 
   return NextResponse.json({ address: derived.address, privateKey: derived.privateKey });
 }


### PR DESCRIPTION
## Summary
- use `HDNodeWallet.fromPhrase` to derive wallets by path
- update API route imports accordingly

## Testing
- `npm run build` *(fails: Failed to fetch Prisma engine)*
- `npx prisma generate` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68448a1a8b988322826e19e0cc82c17e