### PR TITLE
Fix sign-in callback loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ The application uses the following variables:
 - `NEXTAUTH_URL` – Base URL of your deployed site
 - `DATABASE_URL` – PostgreSQL connection string
 
+## Troubleshooting OAuth Loops
+If you see a URL repeatedly redirecting like `/signin?callbackUrl=/signin?...` and end up on an `error=Callback` page, check the following:
+
+1. **Callback URL** – Google must allow `http://localhost:3000/api/auth/callback/google` (or your deployed URL) in its OAuth configuration.
+2. **Callback URL on sign in** – When calling `signIn` in `src/app/signin/page.tsx`, ensure a real page is provided with `callbackUrl: '/'` so the user is redirected after login.
+3. **Matching URLs** – The value of `NEXTAUTH_URL` in your `.env` must exactly match the URL you open in the browser.
+4. **Cookies** – Verify in DevTools that session cookies are being set correctly.
+
+These steps typically resolve callback loops with NextAuth and Google OAuth.
+
 ## Contributing
 See [`contributing.md`](contributing.md) for guidelines.
 

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -5,7 +5,10 @@ import { Button } from "@/components/ui/button"
 export default function SignIn() {
   return (
     <div className="flex items-center justify-center min-h-screen bg-zinc-800">
-      <Button variant="outline" onClick={() => signIn('google')}>
+      <Button
+        variant="outline"
+        onClick={() => signIn("google", { callbackUrl: "/" })}
+      >
         Sign in with Google
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- redirect to root after Google OAuth sign-in
- document how to resolve OAuth callback loops

## Testing
- `npm install`
- `npm run lint` *(fails: Next.js prompts to configure ESLint)*
- `npm run build` *(fails: prisma client not generated)*
- `npx prisma generate` *(fails: 403 when fetching prisma engine)*

------
https://chatgpt.com/codex/tasks/task_e_68449d8ecab8832299adef5fc4886d5c